### PR TITLE
Makes easky-init convert directory names to Lisp package names

### DIFF
--- a/easky.el
+++ b/easky.el
@@ -42,6 +42,8 @@
 (require 'ansi)  ; we need `ansi' to run through Eask API
 (require 'lv)
 (require 'marquee-header)
+(eval-when-compile
+  (require 'subr-x))
 
 (defgroup easky nil
   "Control Eask in Emacs."
@@ -739,7 +741,12 @@ This can be replaced with `easky-package-install' command."
         (easky--inhibit-log (message "Checking filename..."))
         (sleep-for 0.2)))
     ;; Starting Eask-file creation!
-    (let* ((project-name (file-name-nondirectory (directory-file-name default-directory)))
+    (let* ((project-name (thread-last
+                           (file-name-nondirectory (directory-file-name default-directory))
+                           (downcase)
+                           ;; Remove customary prefixes and suffixes in Emacs Lisp repository names
+                           (replace-regexp-in-string (eval-when-compile (rx bos "emacs-")) "")
+                           (replace-regexp-in-string (eval-when-compile (rx (in ".-") "el" eos)) "")))
            (package-name (read-string (format "package name: (%s) " project-name) nil nil project-name))
            (version (read-string "version: (1.0.0) " nil nil "1.0.0"))
            (description (read-string "description: "))


### PR DESCRIPTION
These repository names are common in practice, so it seems worth normalizing the directory names.

 * `emacs-` prefix
 * `[.-]el` suffix