### PR TITLE
Fix split-string pattern to accept `", "`

### DIFF
--- a/easky.el
+++ b/easky.el
@@ -752,15 +752,17 @@ This can be replaced with `easky-package-install' command."
            (emacs-version (read-string "emacs version: (26.1) " nil nil "26.1"))
            (website (read-string "website: "))
            (keywords (read-string "keywords: "))
-           (keywords (split-string keywords "[, ]"))
-           (keywords (string-join keywords "\" \""))
+           (keywords (if (string-match-p "," keywords)
+                         (split-string keywords ",[ \t\n]*" t "[ ]+")
+	               (split-string keywords "[ \t\n]+" t "[ ]+")))
+           (keywords (mapconcat (lambda (s) (format "%S" s)) keywords " "))
            (content (format
                      "(package \"%s\"
          \"%s\"
          \"%s\")
 
 (website-url \"%s\")
-(keywords \"%s\")
+(keywords %s)
 
 (package-file \"%s\")
 


### PR DESCRIPTION
Make the result natural when inputting `foo, bar, awesome topic` as well as `foo,bar` and `foo bar`.

```el
(split-string "foo, bar, awesome topic" "[, ]")
;; => ("foo" "" "bar" "" "awesome" "topic")

(split-string "foo, bar, awesome topic" ",[ \t\n]*" t "[ ]+")
;; => ("foo" "bar" "awesome topic")
```

This logic is a duplicate of [`lm-keywords-list`](https://github.com/emacs-mirror/emacs/blob/a61cc138edeee269e8cf62c13058d5258310d7bc/lisp/emacs-lisp/lisp-mnt.el#L447-L453).